### PR TITLE
util: Add initial dockerfile and README instructions

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,40 +6,28 @@ FROM ubuntu:22.04
 #---------------------
 # Install necessary packages
 #---------------------
-RUN apt-get -y update
-RUN apt-get -y install git
-RUN apt-get -y install autoconf help2man perl python3 make flex bison g++ 
-RUN apt-get -y install libfl2  libfl-dev
-RUN apt-get -y install python3 pip
+RUN apt-get update && apt-get -y install git autoconf help2man perl python3 python3-pip make flex bison g++ libfl2 libfl-dev
 
 #---------------------
 # Compile verilator from source code
 #---------------------
 RUN git clone https://github.com/verilator/verilator
-WORKDIR verilator/
+WORKDIR /verilator
 RUN git checkout v5.006
 ENV VERILATOR_ROOT=/verilator
-RUN autoconf
-RUN ./configure
-RUN make -j `nproc`
+RUN autoconf && ./configure && make -j `nproc`
 RUN make test
 ENV PATH="$VERILATOR_ROOT/bin:$PATH"
 
 #---------------------
 # Installing cocotb
 #---------------------
-WORKDIR tmp/
+WORKDIR /repo
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 #---------------------
-# Importing the hwpe-stream
+# Setting environment variables
 #---------------------
-WORKDIR /
-RUN git clone https://github.com/KULeuven-MICAS/hwpe-stream.git
-# TODO: fix me later
-WORKDIR /hwpe-stream
-RUN git checkout add-cocotb-test
-RUN git pull
 ENV HWPE_STREAM_HOME=/hwpe-stream
-RUN echo "SUCCESS! Don't forget to run setup_cocotb.sh!!!"
+

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -1,0 +1,45 @@
+#---------------------
+# Ubuntu 22.04 base
+#---------------------
+FROM ubuntu:22.04
+
+#---------------------
+# Install necessary packages
+#---------------------
+RUN apt-get -y update
+RUN apt-get -y install git
+RUN apt-get -y install autoconf help2man perl python3 make flex bison g++ 
+RUN apt-get -y install libfl2  libfl-dev
+RUN apt-get -y install python3 pip
+
+#---------------------
+# Compile verilator from source code
+#---------------------
+RUN git clone https://github.com/verilator/verilator
+WORKDIR verilator/
+RUN git checkout v5.006
+ENV VERILATOR_ROOT=/verilator
+RUN autoconf
+RUN ./configure
+RUN make -j `nproc`
+RUN make test
+ENV PATH="$VERILATOR_ROOT/bin:$PATH"
+
+#---------------------
+# Installing cocotb
+#---------------------
+WORKDIR tmp/
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+#---------------------
+# Importing the hwpe-stream
+#---------------------
+WORKDIR /
+RUN git clone https://github.com/KULeuven-MICAS/hwpe-stream.git
+# TODO: fix me later
+WORKDIR /hwpe-stream
+RUN git checkout add-cocotb-test
+RUN git pull
+ENV HWPE_STREAM_HOME=/hwpe-stream
+RUN echo "SUCCESS! Don't forget to run setup_cocotb.sh!!!"

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -1,18 +1,18 @@
 # HWPE Stream Docker Test Container
 The dockerfile contains the build instructions for the container. It is compatible for cocotb and Verilator. 
 
-## Alternative docker download
+## Alternative Docker Download
 You can download an uploaded build by running: 
 ``` bash
 docker pull rgantonio/cocotb-hwpe-stream
 ```
 
-## How to use?
-- Make sure to download the docker
-- Make sure to clone the main hwpe-stream repo:
-- Run the container and mount the hwpe-stream repo:
+## Using the Container
+Run interactive container:
+
 ``` bash
-docker run -it -v $HWPE_STREAM_ROOT/hwpe-stream:/repo -w repo rgantonio/cocotb-hwpe-stream
+docker run -it -v $REPO_TOP:/repo -w repo rgantonio/cocotb-hwpe-stream
 ```
+**Note:** the `$REPO_TOP` is the cloned `hwpe-stream` top. For example, `$REPO_TOP=$HOME/hwpe-stream`.
 
 ## TODO: Update the path later!

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -1,0 +1,10 @@
+# HWPE Stream Dockertest Container
+The dockerfile contains the build instructions for the container. It is compatible for cocotb and Verilator. Once built simply go into the `/cocotb` directory and run `pytest`.
+
+## Alternative docker download
+You can download an uploaded build by running:
+``` bash
+docker pull rgantonio/cocotb-hwpe-stream
+```
+
+## TODO: Update this after. This will be part of initial commit only.

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -1,10 +1,18 @@
-# HWPE Stream Dockertest Container
-The dockerfile contains the build instructions for the container. It is compatible for cocotb and Verilator. Once built simply go into the `/cocotb` directory and run `pytest`.
+# HWPE Stream Docker Test Container
+The dockerfile contains the build instructions for the container. It is compatible for cocotb and Verilator. 
 
 ## Alternative docker download
-You can download an uploaded build by running:
+You can download an uploaded build by running: 
 ``` bash
 docker pull rgantonio/cocotb-hwpe-stream
 ```
 
-## TODO: Update this after. This will be part of initial commit only.
+## How to use?
+- Make sure to download the docker
+- Make sure to clone the main hwpe-stream repo:
+- Run the container and mount the hwpe-stream repo:
+``` bash
+docker run -it -v $HWPE_STREAM_ROOT/hwpe-stream:/repo -w repo rgantonio/cocotb-hwpe-stream
+```
+
+## TODO: Update the path later!

--- a/util/container/requirements.txt
+++ b/util/container/requirements.txt
@@ -1,0 +1,4 @@
+cocotb == 1.8.0
+cocotb-test == 0.2.4
+pytest == 7.4.0
+pyyaml


### PR DESCRIPTION
This is an initial commit and PR for a working dockerfile.

Build was tested and can work well with the add-cocotb-test branch. The basic tests pass :)

Please give feedback on this!

Next step after this is to make the CI!

Advantage of container:
- No need to build specific Verilator code from source. Uploaded container already has binary files (see README.md)
- Same goes for cocotb.

Note: This is better merged after the add-cocotb-test PR!